### PR TITLE
Use import syntax compatible with julia 0.5

### DIFF
--- a/src/GeometricalPredicates.jl
+++ b/src/GeometricalPredicates.jl
@@ -11,7 +11,7 @@ module GeometricalPredicates
 # License: MIT
 # Bug reportss welcome!
 
-import Base.!
+import Base.(!)
 using Compat
 
 export


### PR DESCRIPTION
`import Base.!` doesn't work on julia 0.5 due to vectorization changes. This should maintain compatibility. I didn't have any other issues loading it on julia 0.5.