### PR TITLE
relax Float64 to Real in constructors, add tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeometricalPredicates"
 uuid = "fd0ad045-b25c-564e-8f9c-8ef5c5f21267"
-version = "0.3.0"
+version = "0.4.0"
 
 [compat]
 julia = "≥ 1.0.0"

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ getx(mypoint) # -> 1.1
 gety(mypoint) # -> 1.9
 getz(mypoint) # -> 1.5
 ```
-`Point2D` inherits from `AbstractPoint2D`and `Point3D` inherits from `AbstractPoint3D`.
-You can implement custom point types by inheriting from these abstract types. These
+`Point2D` is a subtype of `AbstractPoint2D`, and `Point3D` is a subtype of `AbstractPoint3D`.
+You can implement custom point types by subtyping these abstract types. These
 custom point types can be used with the rest of the package:
 ```julia
 type MyCustomPointType <: AbstractPoint2D

--- a/src/GeometricalPredicates.jl
+++ b/src/GeometricalPredicates.jl
@@ -100,8 +100,8 @@ getx(p::Point3D) = p._x
 gety(p::Point3D) = p._y
 getz(p::Point3D) = p._z
 
-Point(x::Real, y::Real) = Point2D(float(x), float(y))
-Point(x::Real, y::Real, z::Real) = Point3D(float(x), float(y), float(z))
+Point(x::Real, y::Real) = Point2D(Float64(x), Float64(y))
+Point(x::Real, y::Real, z::Real) = Point3D(Float64(x), Float64(y), Float64(z))
 
 struct Line2D{T<:AbstractPoint2D} <: AbstractLine2D
     _a::T

--- a/src/GeometricalPredicates.jl
+++ b/src/GeometricalPredicates.jl
@@ -100,8 +100,8 @@ getx(p::Point3D) = p._x
 gety(p::Point3D) = p._y
 getz(p::Point3D) = p._z
 
-Point(x::Real, y::Real) = Point2D(x, y)
-Point(x::Real, y::Real, z::Real) = Point3D(x, y, z)
+Point(x::Real, y::Real) = Point2D(float(x), float(y))
+Point(x::Real, y::Real, z::Real) = Point3D(float(x), float(y), float(z))
 
 struct Line2D{T<:AbstractPoint2D} <: AbstractLine2D
     _a::T
@@ -241,10 +241,10 @@ Triangle(a::T, b::T, c::T, ::PositivelyOriented) where {T<:AbstractPoint2D} = Po
 Triangle(a::T, b::T, c::T, ::NegativelyOriented) where {T<:AbstractPoint2D} = NegativelyOrientedTriangle{T}(a, b, c)
 Triangle(a::T, b::T, c::T, ::UnOriented) where {T<:AbstractPoint2D} = UnOrientedTriangle{T}(a, b, c)
 Triangle(a::T, b::T, c::T) where {T<:AbstractPoint2D} = Triangle(a, b, c, unoriented)
-Triangle(ax::Float64, ay::Float64, bx::Float64, by::Float64, cx::Float64, cy::Float64, orientation::AbstractOrientation=unoriented) =
-    Triangle(Point2D(ax, ay), Point2D(bx, by), Point2D(cx, cy), orientation)
-Primitive(ax::Float64, ay::Float64, bx::Float64, by::Float64, cx::Float64, cy::Float64, orientation::AbstractOrientation=unoriented) =
-    Triangle(Point2D(ax, ay), Point2D(bx, by), Point2D(cx, cy), orientation)
+Triangle(ax::Real, ay::Real, bx::Real, by::Real, cx::Real, cy::Real, orientation::AbstractOrientation=unoriented) =
+    Triangle(Point(ax, ay), Point(bx, by), Point(cx, cy), orientation)
+Primitive(ax::Real, ay::Real, bx::Real, by::Real, cx::Real, cy::Real, orientation::AbstractOrientation=unoriented) =
+    Triangle(Point(ax, ay), Point(bx, by), Point(cx, cy), orientation)
 Primitive(a::T, b::T, c::T, orientation::AbstractOrientation=unoriented) where {T<:AbstractPoint2D} =
     Triangle(a, b, c, orientation)
 
@@ -299,12 +299,12 @@ Tetrahedron(a::T, b::T, c::T, d::T, ::PositivelyOriented) where {T<:AbstractPoin
 Tetrahedron(a::T, b::T, c::T, d::T, ::NegativelyOriented) where {T<:AbstractPoint3D} = NegativelyOrientedTetrahedron{T}(a, b, c, d)
 Tetrahedron(a::T, b::T, c::T, d::T, ::UnOriented) where {T<:AbstractPoint3D} = UnOrientedTetrahedron{T}(a, b, c, d)
 Tetrahedron(a::T, b::T, c::T, d::T) where {T<:AbstractPoint3D} = Tetrahedron(a, b, c, d, unoriented)
-Tetrahedron(ax::Float64, ay::Float64, az::Float64, bx::Float64, by::Float64, bz::Float64,
-    cx::Float64, cy::Float64, cz::Float64, dx::Float64, dy::Float64, dz::Float64, orientation::AbstractOrientation=unoriented) =
-        Tetrahedron(Point3D(ax,ay,az), Point3D(bx,by,bz), Point3D(cx,cy,cz), Point3D(dx,dy,dz), orientation)
-Primitive(ax::Float64, ay::Float64, az::Float64, bx::Float64, by::Float64, bz::Float64,
-    cx::Float64, cy::Float64, cz::Float64, dx::Float64, dy::Float64, dz::Float64, orientation::AbstractOrientation=unoriented) =
-        Tetrahedron(Point3D(ax,ay,az), Point3D(bx,by,bz), Point3D(cx,cy,cz), Point3D(dx,dy,dz), orientation)
+Tetrahedron(ax::Real, ay::Real, az::Real, bx::Real, by::Real, bz::Real,
+    cx::Real, cy::Real, cz::Real, dx::Real, dy::Real, dz::Real, orientation::AbstractOrientation=unoriented) =
+        Tetrahedron(Point(ax,ay,az), Point(bx,by,bz), Point(cx,cy,cz), Point(dx,dy,dz), orientation)
+Primitive(ax::Real, ay::Real, az::Real, bx::Real, by::Real, bz::Real,
+    cx::Real, cy::Real, cz::Real, dx::Real, dy::Real, dz::Real, orientation::AbstractOrientation=unoriented) =
+        Tetrahedron(Point(ax,ay,az), Point(bx,by,bz), Point(cx,cy,cz), Point(dx,dy,dz), orientation)
 Primitive(a::T, b::T, c::T, d::T, orientation::AbstractOrientation=unoriented) where {T<:AbstractPoint3D} =
         Tetrahedron(a, b, c, d, orientation)
 
@@ -454,9 +454,9 @@ setcd(t::TetrahedronTypes, pc::AbstractPoint3D, pd::AbstractPoint3D) = (t._c=pc;
 orientation(p::AbstractUnOrientedPrimitive) = p._o
 orientation(p::AbstractPositivelyOrientedPrimitive) = 1
 orientation(p::AbstractNegativelyOrientedPrimitive) = -1
-orientation(ax::Float64, ay::Float64, bx::Float64, by::Float64, cx::Float64, cy::Float64) =
+orientation(ax::Real, ay::Real, bx::Real, by::Real, cx::Real, cy::Real) =
     orientation(Triangle(ax, ay, bx, by, cx, cy))
-orientation(ax::Float64, ay::Float64, az::Float64, bx::Float64, by::Float64, bz::Float64, cx::Float64, cy::Float64, cz::Float64, dx::Float64, dy::Float64, dz::Float64) =
+orientation(ax::Real, ay::Real, az::Real, bx::Real, by::Real, bz::Real, cx::Real, cy::Real, cz::Real, dx::Real, dy::Real, dz::Real) =
     orientation(Tetrahedron(ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz))
 
 # exact orientation for triangle
@@ -605,10 +605,10 @@ function incircle(t::TetrahedronTypes, p::AbstractPoint3D)
 end
 
 # helper methods to use incircle directly with coordinates
-incircle(ax::Float64, ay::Float64, bx::Float64, by::Float64, cx::Float64, cy::Float64, dx::Float64, dy::Float64) =
-    incircle(Triangle(ax, ay, bx, by, cx, cy), Point2D(dx, dy))
-incircle(ax::Float64, ay::Float64, az::Float64, bx::Float64, by::Float64, bz::Float64, cx::Float64, cy::Float64, cz::Float64, dx::Float64, dy::Float64, dz::Float64, ex::Float64, ey::Float64, ez::Float64) =
-    incircle(Tetrahedron(ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz), Point3D(ex, ey, ez))
+incircle(ax::Real, ay::Real, bx::Real, by::Real, cx::Real, cy::Real, dx::Real, dy::Real) =
+    incircle(Triangle(ax, ay, bx, by, cx, cy), Point(dx, dy))
+incircle(ax::Real, ay::Real, az::Real, bx::Real, by::Real, bz::Real, cx::Real, cy::Real, cz::Real, dx::Real, dy::Real, dz::Real, ex::Real, ey::Real, ez::Real) =
+    incircle(Tetrahedron(ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz), Point(ex, ey, ez))
 
 
 # exact intriangle (slow!)
@@ -842,10 +842,10 @@ function intriangle(t::TetrahedronTypes, p::AbstractPoint3D)
 end
 
 # helper  methods to use the filtered (fast, exact) intriangle directly with raw coordinates
-intriangle(ax::Float64, ay::Float64, bx::Float64, by::Float64, cx::Float64, cy::Float64, px::Float64, py::Float64) =
-    intriangle(Triangle(ax, ay, bx, by, cx, cy), Point2D(px, py))
-intriangle(ax::Float64, ay::Float64, az::Float64, bx::Float64, by::Float64, bz::Float64, cx::Float64, cy::Float64, cz::Float64, dx::Float64, dy::Float64, dz::Float64, px::Float64, py::Float64, pz::Float64) =
-    intriangle(Tetrahedron(ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz), Point3D(px, py, pz))
+intriangle(ax::Real, ay::Real, bx::Real, by::Real, cx::Real, cy::Real, px::Real, py::Real) =
+    intriangle(Triangle(ax, ay, bx, by, cx, cy), Point(px, py))
+intriangle(ax::Real, ay::Real, az::Real, bx::Real, by::Real, bz::Real, cx::Real, cy::Real, cz::Real, dx::Real, dy::Real, dz::Real, px::Real, py::Real, pz::Real) =
+    intriangle(Tetrahedron(ax, ay, az, bx, by, bz, cx, cy, cz, dx, dy, dz), Point(px, py, pz))
 
 
 ###################################################################################

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,17 @@ using GeometricalPredicates
 using Test
 
 @testset "2D orientation" begin
+    @testset "Points" begin
+        p = Point(1,1)
+        @test getx(p) === 1.0
+        @test gety(p) === 1.0
+
+        p = Point(1, 1, 1)
+        @test getx(p) === 1.0
+        @test gety(p) === 1.0
+        @test getz(p) === 1.0
+    end
+    
     @testset "Lines" begin
         a = Point(1.1, 1.1)
         b = Point(1.5, 1.5)
@@ -17,6 +28,21 @@ using Test
         @test orientation(l, Point(1.4,1.4)) == 0
 
         @test abs(length2(l)-0.4*0.4*2) < 1e-5
+
+        a = Point(1, 1)
+        b = Point(2, 2)
+
+        l = Line(a, b)
+        @test orientation(l, Point(1.4, 1.6)) == 1
+        @test orientation(l, Point(1.4,1.05)) == -1
+        @test orientation(l, Point(1.4,1.4)) == 0
+
+        l = Line(b, a)
+        @test orientation(l, Point(1.4, 1.6)) == -1
+        @test orientation(l, Point(1.4,1.05)) == 1
+        @test orientation(l, Point(1.4,1.4)) == 0
+
+        @test abs(length2(l)-2) < 1e-5
     end
 
     @testset "Triangles" begin
@@ -55,7 +81,7 @@ using Test
         @test orientation(bx,by,ax,ay,cx,cy) == 1
         @test orientation(bx,by,cx,cy,ax,ay) == -1
 
-        p1 = Point2D(1.0, 1.0)
+        p1 = Point(1, 1)
         p2 = Point2D(1.9, 1.5)
         p3 = Point2D(1.45, 1.25)
         tr = Triangle(p1, p2, p3)
@@ -83,11 +109,20 @@ end
     cx = 1.3; cy = 1.3
     dx = 1.4; dy = 1.7
     @test incircle(ax,ay,bx,by,cx,cy,dx,dy) == 2
+    ax = 1; ay = 1
+    @test incircle(ax,ay,bx,by,cx,cy,dx,dy) == 2
 
     ax = 1.1; ay = 1.1
     bx = 1.3; by = 1.1
     cx = 1.3; cy = 1.3
     dx = 1.1; dy = 1.3
+    @test incircle(ax,ay,bx,by,cx,cy,dx,dy) == 0
+    @test incircle(bx,by,ax,ay,cx,cy,dx,dy) == 0
+    @test incircle(bx,by,cx,cy,ax,ay,dx,dy) == 0
+    ax = 1; ay = 1
+    bx = 1.3; by = 1
+    cx = 1.3; cy = 1.3
+    dx = 1; dy = 1.3
     @test incircle(ax,ay,bx,by,cx,cy,dx,dy) == 0
     @test incircle(bx,by,ax,ay,cx,cy,dx,dy) == 0
     @test incircle(bx,by,cx,cy,ax,ay,dx,dy) == 0
@@ -124,7 +159,7 @@ end
     @test incircle(bx,by,ax,ay,cx,cy,dx,dy) == 1
     @test incircle(bx,by,cx,cy,ax,ay,dx,dy) == 1
 
-    p1 = Point2D(1.0, 1.0)
+    p1 = Point(1, 1)
     p2 = Point2D(1.0625, 1.0)
     p3 = Point2D(1.0625, 1.0625)
     tr = Triangle(p1, p2, p3)
@@ -444,7 +479,7 @@ end
         @test peanokey(Point2D(1.01,1.01), 2) == 0
         @test peanokey(Point2D(1.9901,1.01), 2) == 4*4-1
         @test Point2D(15, 2) == Point2D(1.75, 1.0)
-        @test Point2D(0, 2) == Point2D(1.0, 1.0)
+        @test Point2D(0, 2) == Point(1, 1)
         for x in range(1.0,stop=1.999999,length=100), y in range(1.0,stop=1.999999,length=100)
             p = Point2D(x, y)
             d = peanokey(p)
@@ -491,7 +526,7 @@ end
 
 @testset "Qttys functions" begin
     @testset "2D" begin
-        a = Point2D(1.0, 1.0)
+        a = Point(1, 1)
         b = Point2D(1.0, 1.5)
         c = Point2D(1.5, 1.0)
         t = Triangle(a, b, c)


### PR DESCRIPTION
The internals remain unchanged, because the fields remain of hardcoded `Float64` type.

Closes #33 and closes #22.