### PR TITLE
remove map function to fix overflow error with large Polygons

### DIFF
--- a/src/GeometricalPredicates.jl
+++ b/src/GeometricalPredicates.jl
@@ -165,8 +165,9 @@ struct Polygon2D{T<:AbstractPoint2D} <: AbstractPolygon2D
     _p::Vector{T}
     _l::Vector{AbstractLine2D}
     function Polygon2D{T}(p::T...) where {T<:AbstractPoint2D}
-        l = map(1:length(p)-1) do i
-            Line(p[i], p[i+1])
+        l = []
+        for i in range(1, stop=length(p)-1)
+            push!(l, Line(p[i], p[i+1]))
         end
         push!(l, Line(p[end], p[1]))
         new([p...;], l)

--- a/src/GeometricalPredicates.jl
+++ b/src/GeometricalPredicates.jl
@@ -165,7 +165,7 @@ struct Polygon2D{T<:AbstractPoint2D} <: AbstractPolygon2D
     _p::Vector{T}
     _l::Vector{AbstractLine2D}
     function Polygon2D{T}(p::T...) where {T<:AbstractPoint2D}
-        l = []
+        l = Vector{Line}(undef, length(p)-1)
         for i in range(1, stop=length(p)-1)
             push!(l, Line(p[i], p[i+1]))
         end

--- a/src/GeometricalPredicates.jl
+++ b/src/GeometricalPredicates.jl
@@ -167,7 +167,7 @@ struct Polygon2D{T<:AbstractPoint2D} <: AbstractPolygon2D
     function Polygon2D{T}(p::T...) where {T<:AbstractPoint2D}
         l = Vector{Line}(undef, length(p)-1)
         for i in range(1, stop=length(p)-1)
-            push!(l, Line(p[i], p[i+1]))
+            l[i] = Line(p[i], p[i+1])
         end
         push!(l, Line(p[end], p[1]))
         new([p...;], l)


### PR DESCRIPTION
When passing an array of `Points` with a length of 580754 to `Polygon`, i.e.  `Polygon(points...)`,  I get :
```julia
ERROR: StackOverflowError:
Stacktrace:
 [1] map(f::Function, A::UnitRange{Int64})
   @ Base ./abstractarray.jl:2294
 [2] Polygon2D{Point2D}(::Point2D, ::Vararg{Point2D, N} where N)
   @ GeometricalPredicates ~/.julia/packages/GeometricalPredicates/OoUPy/src/GeometricalPredicates.jl:168
 [3] Polygon2D(::Point2D, ::Vararg{Point2D, N} where N)
   @ GeometricalPredicates ~/.julia/packages/GeometricalPredicates/OoUPy/src/GeometricalPredicates.jl:176
 [4] Polygon(::Point2D, ::Vararg{Point2D, N} where N)
   @ GeometricalPredicates ~/.julia/packages/GeometricalPredicates/OoUPy/src/GeometricalPredicates.jl:178
 [5] top-level scope
   @ ./REPL[50]:6
```
If I replace the `map` call with a `for` loop the overflow error no longer occurs.


