### PR TITLE
Fix precompilation on x86

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,7 @@ jobs:
           #- macOS-latest
         arch:
           - x64
+          - x86
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/GeometricalPredicates.jl
+++ b/src/GeometricalPredicates.jl
@@ -941,7 +941,7 @@ const quadrants_arr = [
   3, 4, 0, 7, 2, 5, 1, 6,
   4, 5, 7, 6, 3, 2, 0, 1,
   5, 2, 6, 1, 4, 3, 7, 0]
-quadrants(a::Int64, b::Int64, c::Int64, d::Int64) = (@inbounds x = quadrants_arr[1+a<<3+b<<2+c<<1+d]; x)
+quadrants(a::Int, b::Int, c::Int, d::Int) = (@inbounds x = quadrants_arr[1+a<<3+b<<2+c<<1+d]; x)
 rotxmap_table = [4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 17, 18, 19, 16, 23, 20, 21, 22]
 rotymap_table = [1, 2, 3, 0, 16, 17, 18, 19, 11, 8, 9, 10, 22, 23, 20, 21, 14, 15, 12, 13, 4, 5, 6, 7]
 rotx_table = [3, 0, 0, 2, 2, 0, 0, 1]


### PR DESCRIPTION
For 64-bit, `Int` and `Int64` are the same so it won't change the behavior for 64-bit.
For 32-bit, it was not precompiling before and it is now so that's an improvement.

I don't expect tests will pass for 32-bit but having it precompile is a first step.

Closes https://github.com/JuliaGeometry/GeometricalPredicates.jl/issues/43